### PR TITLE
Implement simple DNS based discovery.

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -28,23 +28,25 @@ type DNSDiscoverer struct {
 	// QueryHost is the hostname that is queried.
 	QueryHost string
 
-	// NewTargets returns the targets that are discovered based on the discover
-	// of a network address.
+	// NewTargets returns the targets that are discovered based on the addition
+	// of a new network address to the DNS query result.
 	//
 	// addr is the address discovered by the DNS query. It may be a hostname or
 	// an IP address.
 	//
-	// If NewTargets is nil the discover constructs a single Target for each
+	// If NewTargets is nil the discoverer constructs a single Target for each
 	// discovered address. The target name is the discovered address and no
 	// explicit port is specified.
 	NewTargets func(ctx context.Context, addr string) (targets []Target, err error)
 
-	// Resolver is the DNS resolver used to make queries. If it is nil
-	// net.DefaultResolver is used.
+	// Resolver is the DNS resolver used to make queries.
+	//
+	// If it is nil, net.DefaultResolver is used.
 	Resolver DNSResolver
 
-	// QueryInterval is the interval at which DNS queries are performed. If it
-	// is non-positive the DefaultDNSQueryInterval constant is used.
+	// QueryInterval is the interval at which DNS queries are performed.
+	//
+	// If it is non-positive, the DefaultDNSQueryInterval constant is used.
 	QueryInterval time.Duration
 
 	// targets is the set of targets currently known to the discoverer.

--- a/dns.go
+++ b/dns.go
@@ -1,0 +1,179 @@
+package discoverkit
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/dogmatiq/linger"
+)
+
+// DNSResolver is an interface for the subset of net.Resolver used by
+// DNSDiscoverer.
+type DNSResolver interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
+}
+
+const (
+	// DefaultDNSQueryInterval is the default interval at which DNS queries are
+	// performed.
+	DefaultDNSQueryInterval = 10 * time.Second
+)
+
+// DNSDiscoverer is a Discoverer that performs a DNS query to discover targets.
+//
+// It queries a single host and treats each A, AAAA or CNAME record in the
+// result as a distinct target. This is not a DNS-SD implementation.
+type DNSDiscoverer struct {
+	// QueryHost is the hostname that is queried.
+	QueryHost string
+
+	// NewTargets returns the targets that are discovered based on the discover
+	// of a network address.
+	//
+	// addr is the address discovered by the DNS query. It may be a hostname or
+	// an IP address.
+	//
+	// If NewTargets is nil the discover constructs a single Target for each
+	// discovered address. The target name is the discovered address and no
+	// explicit port is specified.
+	NewTargets func(ctx context.Context, addr string) (targets []Target, err error)
+
+	// Resolver is the DNS resolver used to make queries. If it is nil
+	// net.DefaultResolver is used.
+	Resolver DNSResolver
+
+	// QueryInterval is the interval at which DNS queries are performed. If it
+	// is non-positive the DefaultDNSQueryInterval constant is used.
+	QueryInterval time.Duration
+
+	// targets is the set of targets currently known to the discoverer.
+	targets map[string][]DiscoveredTarget
+}
+
+// Discover notifies o of targets that are discovered or undiscovered until ctx
+// is canceled or an error occurs.
+func (d *DNSDiscoverer) Discover(ctx context.Context, o TargetObserver) error {
+	defer func() {
+		for _, targets := range d.targets {
+			for _, t := range targets {
+				o.TargetUndiscovered(t)
+			}
+		}
+	}()
+
+	for {
+		addrs, err := d.query(ctx)
+		if err != nil {
+			return err
+		}
+
+		if err := d.update(ctx, addrs, o); err != nil {
+			return err
+		}
+
+		if err := linger.Sleep(
+			ctx,
+			d.QueryInterval,
+			DefaultDNSQueryInterval,
+		); err != nil {
+			return err
+		}
+	}
+}
+
+// update sends notifications to o about the targets that have become
+// available/unavailable based on new query results.
+func (d *DNSDiscoverer) update(
+	ctx context.Context,
+	addrs []string,
+	o TargetObserver,
+) error {
+	prev := d.targets
+	d.targets = make(map[string][]DiscoveredTarget, len(addrs))
+
+	// Add an entry to d.targets for each of the addresses in the query result.
+	for _, addr := range addrs {
+		if targets, ok := prev[addr]; ok {
+			// We have already discovered this address. It may or may not have
+			// any targets. Either way we retain them unchanged.
+			d.targets[addr] = targets
+			continue
+		}
+
+		// Otherwise, we're seeing this address for the first time, or it's
+		// reappeared after being removed from the DNS results. We construct the
+		// targets that are at this address.
+		targets, err := d.newTargets(ctx, addr)
+		if err != nil {
+			return err
+		}
+
+		if len(targets) == 0 {
+			// Explicitly store a nil slice against this address if there are no
+			// targets. This ensures that we still treat the address as "seen".
+			d.targets[addr] = nil
+			continue
+		}
+
+		// Make a DiscoveredTarget for each Target and notify the observer.
+		discovered := make([]DiscoveredTarget, len(targets))
+		for i, t := range targets {
+			dt := DiscoveredTarget{
+				Target:     t,
+				ID:         DiscoveredTargetID(),
+				Discoverer: d,
+			}
+
+			discovered[i] = dt
+			o.TargetDiscovered(dt)
+		}
+
+		// Store the discovered targets against the address.
+		d.targets[addr] = discovered
+	}
+
+	// Notify the observer of any targets that have gone away because the
+	// address they were based on is no longer in the query results.
+	for a, targets := range prev {
+		if _, ok := d.targets[a]; !ok {
+			for _, dt := range targets {
+				o.TargetUndiscovered(dt)
+			}
+		}
+	}
+
+	return nil
+}
+
+// query performs a DNS query to find API targets.
+func (d *DNSDiscoverer) query(ctx context.Context) ([]string, error) {
+	r := d.Resolver
+	if r == nil {
+		r = net.DefaultResolver
+	}
+
+	addrs, err := r.LookupHost(ctx, d.QueryHost)
+	if err != nil {
+		if x, ok := err.(*net.DNSError); ok {
+			if x.IsTemporary || x.IsNotFound {
+				return nil, nil
+			}
+		}
+
+		return nil, err
+	}
+
+	return addrs, nil
+}
+
+// newTarget returns the targets at the given address.
+func (d *DNSDiscoverer) newTargets(ctx context.Context, addr string) ([]Target, error) {
+	if d.NewTargets != nil {
+		return d.NewTargets(ctx, addr)
+	}
+
+	return []Target{
+		{Name: addr},
+	}, nil
+}

--- a/dns_test.go
+++ b/dns_test.go
@@ -1,0 +1,273 @@
+package discoverkit_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	. "github.com/dogmatiq/discoverkit"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type DNSDiscoverer", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		obs    *targetObserverStub
+		res    *dnsResolverStub
+		disc   *DNSDiscoverer
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel = context.WithCancel(ctx)
+
+		obs = &targetObserverStub{}
+
+		res = &dnsResolverStub{}
+
+		disc = &DNSDiscoverer{
+			QueryHost: "<query-host>",
+			Resolver:  res,
+		}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func Discover()", func() {
+		It("notifies the observer of discovery when addresses are found", func() {
+			res.LookupHostFunc = func(_ context.Context, host string) ([]string, error) {
+				cancel()
+
+				Expect(host).To(Equal("<query-host>"))
+				return []string{"<addr-1>", "<addr-2>"}, nil
+			}
+
+			var targets []Target
+			obs.TargetDiscoveredFunc = func(t DiscoveredTarget) {
+				Expect(t.ID).To(BeNumerically(">", 0))
+				Expect(t.Discoverer).To(Equal(disc))
+
+				targets = append(targets, t.Target)
+			}
+
+			err := disc.Discover(ctx, obs)
+			Expect(err).To(Equal(context.Canceled))
+			Expect(targets).To(ConsistOf(
+				Target{
+					Name: "<addr-1>",
+				},
+				Target{
+					Name: "<addr-2>",
+				},
+			))
+		})
+
+		It("notifies the observer of undiscovery when addresses go away", func() {
+			disc.QueryInterval = 10 * time.Millisecond
+
+			res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+				// Replace this function on the stub so that it returns a subset
+				// of the addresses that it returned the first time.
+				res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+					return []string{"<addr-2>"}, nil
+				}
+
+				return []string{"<addr-1>", "<addr-2>"}, nil
+			}
+
+			obs.TargetUndiscoveredFunc = func(t DiscoveredTarget) {
+				Expect(t.Target).To(Equal(
+					Target{
+						Name: "<addr-1>",
+					},
+				))
+
+				// Remove this function from the stub to prevent a failure when
+				// <addr-2> becomes unavailable when the discover is stopped.
+				obs.TargetUndiscoveredFunc = nil
+
+				cancel()
+			}
+
+			err := disc.Discover(ctx, obs)
+			Expect(err).To(Equal(context.Canceled))
+		})
+
+		It("notifies the observer of undiscovery when the discoverer is stopped", func() {
+			disc.QueryInterval = 10 * time.Millisecond
+
+			res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+				cancel()
+				return []string{"<addr-1>", "<addr-2>"}, nil
+			}
+
+			targets := map[uint64]DiscoveredTarget{}
+
+			obs.TargetDiscoveredFunc = func(t DiscoveredTarget) {
+				targets[t.ID] = t
+			}
+
+			obs.TargetUndiscoveredFunc = func(t DiscoveredTarget) {
+				x := targets[t.ID]
+				Expect(t).To(Equal(x))
+				delete(targets, t.ID)
+			}
+
+			err := disc.Discover(ctx, obs)
+			Expect(err).To(Equal(context.Canceled))
+			Expect(targets).To(BeEmpty())
+		})
+
+		It("uses net.DefaultResolver by default", func() {
+			disc.QueryHost = "localhost"
+			disc.Resolver = nil
+
+			obs.TargetDiscoveredFunc = func(t DiscoveredTarget) {
+				cancel()
+
+				Expect(t.Name).To(
+					Or(
+						Equal("127.0.0.1"),
+						Equal("::1"),
+					),
+				)
+			}
+
+			err := disc.Discover(ctx, obs)
+			Expect(err).To(Equal(context.Canceled))
+		})
+
+		When("there is a NewTargets() function", func() {
+			It("uses the targets returned by NewTargets()", func() {
+				disc.NewTargets = func(_ context.Context, addr string) ([]Target, error) {
+					return []Target{
+						{Name: addr + "-A"},
+						{Name: addr + "-B"},
+					}, nil
+				}
+
+				res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+					cancel()
+					return []string{"<addr-1>", "<addr-2>"}, nil
+				}
+
+				var targets []Target
+				obs.TargetDiscoveredFunc = func(t DiscoveredTarget) {
+					targets = append(targets, t.Target)
+				}
+
+				err := disc.Discover(ctx, obs)
+				Expect(err).To(Equal(context.Canceled))
+				Expect(targets).To(ConsistOf(
+					Target{
+						Name: "<addr-1>-A",
+					},
+					Target{
+						Name: "<addr-1>-B",
+					},
+					Target{
+						Name: "<addr-2>-A",
+					},
+					Target{
+						Name: "<addr-2>-B",
+					},
+				))
+			})
+
+			It("properly tracks addresses for which NewTargets() returns an empty slice", func() {
+				disc.QueryInterval = 10 * time.Millisecond
+
+				disc.NewTargets = func(context.Context, string) ([]Target, error) {
+					// Replace this function on the stub to ensure that it
+					// doesn't get called again for the same address.
+					disc.NewTargets = func(context.Context, string) ([]Target, error) {
+						Fail("unexpected second invocation of NewTargets()")
+						return nil, nil
+					}
+
+					return nil, nil
+				}
+
+				res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+					// Replace this function on the stub to cancel the context
+					// the *second* time that it is called.
+					res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+						cancel()
+
+						// Return the same address on this second invocation,
+						// ensuring that NewTargets() would be called again if
+						// addresses with no associated targets were not tracked
+						// correctly.
+						return []string{"<addr>"}, nil
+					}
+
+					return []string{"<addr>"}, nil
+				}
+
+				obs.TargetDiscoveredFunc = func(t DiscoveredTarget) {
+					Fail("unexpoected notification of discovered target")
+				}
+
+				err := disc.Discover(ctx, obs)
+				Expect(err).To(Equal(context.Canceled))
+			})
+
+			It("returns an error if NewTargets() returns an error", func() {
+				disc.NewTargets = func(context.Context, string) ([]Target, error) {
+					return nil, errors.New("<error>")
+				}
+
+				res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+					return []string{"<addr>"}, nil
+				}
+
+				err := disc.Discover(ctx, obs)
+				Expect(err).To(MatchError("<error>"))
+			})
+		})
+
+		When("the resolver fails", func() {
+			It("does not propagate not-found errors", func() {
+				res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+					cancel()
+					return nil, &net.DNSError{
+						IsNotFound: true,
+					}
+				}
+
+				err := disc.Discover(ctx, obs)
+				Expect(err).To(Equal(context.Canceled)) // note: not the net.DNSError
+			})
+
+			It("propagates other errors", func() {
+				res.LookupHostFunc = func(context.Context, string) ([]string, error) {
+					return nil, errors.New("<error>")
+				}
+
+				err := disc.Discover(ctx, obs)
+				Expect(err).To(MatchError("<error>"))
+			})
+		})
+	})
+})
+
+// dnsResolverStub is a test implementation of the DNSResolver interface.
+type dnsResolverStub struct {
+	LookupHostFunc func(ctx context.Context, host string) ([]string, error)
+}
+
+// LookupHost calls r.LookHostFunc(ctx, host) if it is non-nil.
+func (r *dnsResolverStub) LookupHost(ctx context.Context, host string) ([]string, error) {
+	if r.LookupHostFunc == nil {
+		return nil, &net.DNSError{
+			IsNotFound: true,
+		}
+	}
+
+	return r.LookupHostFunc(ctx, host)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dogmatiq/discoverkit
 go 1.15
 
 require (
+	github.com/dogmatiq/linger v0.2.1
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.4
 	google.golang.org/grpc v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dogmatiq/linger v0.2.1 h1:ecVwiFlTcQuQ7ygQXH5bUPkWNve8n5BmVnCYMGMQ3zc=
+github.com/dogmatiq/linger v0.2.1/go.mod h1:vQPEiGNtb3Qy+1IdmdSMyLxr4d9vPChknnQkClQimGM=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
@@ -34,10 +36,12 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
+github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.4 h1:NiTx7EEvBzu9sFOD1zORteLSt3o8gnlvZZwSE9TnY9U=
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
@@ -84,6 +88,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR implements "simple" DNS based discovery.  This is not "DNS-SD", but rather a mechanism that queries a single host and treats each address in the result as a separate target.

#### Why make this change?

This is part of migrating the discovery system from `dogmatiq/configkit`.  This particular discoverer is useful under Docker: It is possible to give multiple separate services the same alias on a network. Performing a DNS query against that alias name returns the addresses of all of the containers running across all of those services.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Partially addresses #1
Based on the branch of PR #7 
