### PR TITLE
Implement `Connector`.

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -1,0 +1,116 @@
+package discoverkit
+
+import (
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+// Connector is a TargetObserver implementation that dials each discovered
+// target and notifies a ConnectionObserver when connections become available or
+// unavailable.
+type Connector struct {
+	// Observer is the observer to notify about gRPC connections.
+	Observer ConnectionObserver
+
+	// Dial is the function used to dial gRPC targets.
+	//
+	// If it is nil, grpc.Dial() is used.
+	Dial func(string, ...grpc.DialOption) (*grpc.ClientConn, error)
+
+	// DialOptions is a set of default gRPC dial options that are applied
+	// before each target's own dial options.
+	DialOptions []grpc.DialOption
+
+	// Ignore is a predicate function that returns true if the given target
+	// should be ignored.
+	//
+	// Ignored targets are never dialed, and hence the observer is never
+	// notified about them.
+	//
+	// If it is nil, no targets are ignored.
+	Ignore func(DiscoveredTarget) bool
+
+	// OnDialError is a function that is called when a call to Dial() fails.
+	//
+	// Typically dialing only fails if there's some problem with the dial
+	// options. By default, underlying connection is established lazily *after*
+	// the dialer returns.
+	//
+	// If it is nil, dialing errors are silently ignored.
+	OnDialError func(DiscoveredTarget, error)
+
+	m           sync.Mutex
+	connections map[uint64]*grpc.ClientConn
+}
+
+// TargetDiscovered is called when a discoverer becomes aware of a target.
+//
+// It attempts to dial the target and if successful it notifies the observer of
+// the new connection.
+func (c *Connector) TargetDiscovered(t DiscoveredTarget) {
+	if c.Ignore != nil && c.Ignore(t) {
+		return
+	}
+
+	dial := c.Dial
+	if dial == nil {
+		dial = grpc.Dial
+	}
+
+	var options []grpc.DialOption
+	options = append(options, c.DialOptions...)
+	options = append(options, t.DialOptions...)
+
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if c.connections == nil {
+		c.connections = map[uint64]*grpc.ClientConn{}
+	} else if _, ok := c.connections[t.ID]; ok {
+		// This target has already been discovered. This should never occur but
+		// is added to account for misbehaving Discoverer implementations.
+		return
+	}
+
+	conn, err := dial(t.Name, options...)
+	if err != nil {
+		if c.OnDialError != nil {
+			c.OnDialError(t, err)
+		}
+
+		return
+	}
+
+	c.connections[t.ID] = conn
+	c.Observer.ConnectionAvailable(t, conn)
+}
+
+// TargetUndiscovered is called when a previously discovered target is no longer
+// considered to exist.
+//
+// If a connection has been dialed for this target the observer is first
+// notified that the connection is no longer available and then the connection
+// is closed.
+func (c *Connector) TargetUndiscovered(t DiscoveredTarget) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if conn, ok := c.connections[t.ID]; ok {
+		delete(c.connections, t.ID)
+		c.Observer.ConnectionUnavailable(t, conn)
+		conn.Close()
+	}
+}
+
+// ConnectionObserver is notified when a connection to a target becomes
+// available or unavailable.
+type ConnectionObserver interface {
+	// ConnectionAvailable is called when a connection to a target becomes
+	// available.
+	ConnectionAvailable(DiscoveredTarget, grpc.ClientConnInterface)
+
+	// ConnectionUnavailable is called when a connection to a target becomes
+	// unavailable.
+	ConnectionUnavailable(DiscoveredTarget, grpc.ClientConnInterface)
+}

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,193 @@
+package discoverkit_test
+
+import (
+	"errors"
+	"sync"
+
+	. "github.com/dogmatiq/discoverkit"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+)
+
+var _ = Describe("type Connector", func() {
+	var (
+		target1, target2 DiscoveredTarget
+		obs              *connectionObserverStub
+		connector        *Connector
+	)
+
+	BeforeEach(func() {
+		target1 = DiscoveredTarget{
+			Target: Target{
+				Name: "<target-1>",
+				DialOptions: []grpc.DialOption{
+					grpc.WithInsecure(),
+				},
+			},
+			ID: DiscoveredTargetID(),
+		}
+
+		target2 = DiscoveredTarget{
+			Target: Target{
+				Name: "<target-2>",
+				DialOptions: []grpc.DialOption{
+					grpc.WithInsecure(),
+				},
+			},
+			ID: DiscoveredTargetID(),
+		}
+
+		obs = &connectionObserverStub{}
+
+		connector = &Connector{
+			Observer: obs,
+		}
+	})
+
+	Describe("func TargetDiscovered()", func() {
+		It("notifies the observer of connection availability", func() {
+			called := false
+			obs.ConnectionAvailableFunc = func(
+				t DiscoveredTarget,
+				conn grpc.ClientConnInterface,
+			) {
+				Expect(t).To(Equal(target1))
+				Expect(conn).NotTo(BeNil())
+				called = true
+			}
+
+			connector.TargetDiscovered(target1)
+
+			Expect(called).To(BeTrue())
+		})
+
+		It("does not notify the observer if the target has already been discovered", func() {
+			connector.TargetDiscovered(target1)
+
+			obs.ConnectionAvailableFunc = func(
+				DiscoveredTarget,
+				grpc.ClientConnInterface,
+			) {
+				Fail("unexpected call")
+			}
+
+			connector.TargetDiscovered(target1)
+		})
+
+		When("there is an ignore predicate", func() {
+			BeforeEach(func() {
+				connector.Ignore = func(t DiscoveredTarget) bool {
+					return t.ID == target1.ID
+				}
+			})
+
+			It("notifies the observer if the target is not ignored", func() {
+				called := false
+				obs.ConnectionAvailableFunc = func(
+					t DiscoveredTarget,
+					_ grpc.ClientConnInterface,
+				) {
+					Expect(t).To(Equal(target2))
+					called = true
+				}
+
+				connector.TargetDiscovered(target2)
+
+				Expect(called).To(BeTrue())
+			})
+
+			It("does not notify the observer if the target is ignored", func() {
+				obs.ConnectionAvailableFunc = func(
+					DiscoveredTarget,
+					grpc.ClientConnInterface,
+				) {
+					Fail("unexpected call")
+				}
+
+				connector.TargetDiscovered(target1)
+			})
+		})
+
+		When("dialing fails", func() {
+			BeforeEach(func() {
+				connector.Dial = func(string, ...grpc.DialOption) (*grpc.ClientConn, error) {
+					return nil, errors.New("<error>")
+				}
+			})
+
+			It("ignores the error", func() {
+				obs.ConnectionAvailableFunc = func(
+					DiscoveredTarget,
+					grpc.ClientConnInterface,
+				) {
+					Fail("unexpected call")
+				}
+
+				connector.TargetDiscovered(target1)
+			})
+
+			It("invokes the OnDialError() function if it is present", func() {
+				called := false
+				connector.OnDialError = func(
+					t DiscoveredTarget,
+					err error,
+				) {
+					Expect(t).To(Equal(target1))
+					Expect(err).To(MatchError("<error>"))
+					called = true
+				}
+
+				connector.TargetDiscovered(target1)
+
+				Expect(called).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("func TargetUndiscovered()", func() {
+		It("notifies the observer of connection unavailability", func() {
+			connector.TargetDiscovered(target1)
+
+			called := false
+			obs.ConnectionUnavailableFunc = func(
+				t DiscoveredTarget,
+				conn grpc.ClientConnInterface,
+			) {
+				Expect(t).To(Equal(target1))
+				Expect(conn).NotTo(BeNil())
+				called = true
+			}
+
+			connector.TargetUndiscovered(target1)
+
+			Expect(called).To(BeTrue())
+		})
+	})
+})
+
+// connectionObserverStub is a test implementation of the ConnectionObserver
+// interface.
+type connectionObserverStub struct {
+	m                         sync.Mutex
+	ConnectionAvailableFunc   func(DiscoveredTarget, grpc.ClientConnInterface)
+	ConnectionUnavailableFunc func(DiscoveredTarget, grpc.ClientConnInterface)
+}
+
+// ConnectionAvailable calls o.ConnectionAvailableFunc(t,conn) if it is non-nil.
+func (o *connectionObserverStub) ConnectionAvailable(t DiscoveredTarget, c grpc.ClientConnInterface) {
+	if o.ConnectionAvailableFunc != nil {
+		o.m.Lock()
+		defer o.m.Unlock()
+		o.ConnectionAvailableFunc(t, c)
+	}
+}
+
+// ConnectionUnavailable calls o.ConnectionUnavailableFunc(t,conn) if it is non-nil.
+func (o *connectionObserverStub) ConnectionUnavailable(t DiscoveredTarget, c grpc.ClientConnInterface) {
+	if o.ConnectionUnavailableFunc != nil {
+		o.m.Lock()
+		defer o.m.Unlock()
+		o.ConnectionUnavailableFunc(t, c)
+	}
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `Connector` type which is an implementation of the `TargetObserver` interface. Whenever it is notified of a new target it attempts to dial a gRPC connection to that target. If it is successful it notifies a `ConnectionObserver` (an interface also introduced in this PR).

If/when the target is "undiscovered" it notifies the `ConnectionObserver` that connection is now unavailable then closes it.

#### Why make this change?

This is part of the migration from configkit.  The connector is organised as a separate component so that the responsibility for dialing discovered gRPC targets is separated from the discovery logic itself.

#### Is there anything you are unsure about?

~No~ Edit: I'm not sure if this is the best decision, but I have made the `ConnectionObserver` interface work with connections via the `grpc.ClientConnInterface` interface, as opposed to accepting a `*grpc.ClientConn` directly.  

The rationale for using the interface is that it insulates the observer from specifics of the connection implementation. The observer should be able to use the connection to construct specific service clients, but it should not be able to close the connection.

#### What issues does this relate to?

Partially addresses #1.
