### PR TITLE
Remove `DiscoveredTarget`.

### DIFF
--- a/discoverer.go
+++ b/discoverer.go
@@ -2,7 +2,6 @@ package discoverkit
 
 import (
 	"context"
-	"sync/atomic"
 )
 
 // Discoverer is an interface for services that discover gRPC Targets.
@@ -12,34 +11,18 @@ type Discoverer interface {
 	Discover(ctx context.Context, o TargetObserver) error
 }
 
-// DiscoveredTarget is a Target that was discovered by a discoverer.
-type DiscoveredTarget struct {
-	Target
-
-	// ID is a unique identifier for the target.
-	// It must be unique within the current process.
-	ID uint64
-
-	// Discoverer is the discoverer that located this target.
-	Discoverer Discoverer
-}
-
-var nextID uint64
-
-// DiscoveredTargetID allocates a new unique ID for a DiscoveredTarget.
-func DiscoveredTargetID() uint64 {
-	return atomic.AddUint64(&nextID, 1)
-}
-
 // TargetObserver is notified when a target is discovered or undiscovered.
 type TargetObserver interface {
 	// TargetDiscovered is called when a discoverer becomes aware of a target.
 	//
 	// The target is not necessarily online, or if it is online, not necessarily
 	// available to serve requests.
-	TargetDiscovered(DiscoveredTarget)
+	TargetDiscovered(*Target)
 
 	// TargetUndiscovered is called when a previously discovered target is no
 	// longer considered to exist.
-	TargetUndiscovered(DiscoveredTarget)
+	//
+	// t must have previously been passed to TargetDiscovered. That is, the
+	// pointer address itself.
+	TargetUndiscovered(*Target)
 }

--- a/discoverer_test.go
+++ b/discoverer_test.go
@@ -9,12 +9,12 @@ import (
 // targetObserverStub is a test implementation of the TargetObserver interface.
 type targetObserverStub struct {
 	m                      sync.Mutex
-	TargetDiscoveredFunc   func(DiscoveredTarget)
-	TargetUndiscoveredFunc func(DiscoveredTarget)
+	TargetDiscoveredFunc   func(*Target)
+	TargetUndiscoveredFunc func(*Target)
 }
 
 // TargetDiscovered calls o.TargetDiscoveredFunc(t) if it is non-nil.
-func (o *targetObserverStub) TargetDiscovered(t DiscoveredTarget) {
+func (o *targetObserverStub) TargetDiscovered(t *Target) {
 	if o.TargetDiscoveredFunc != nil {
 		o.m.Lock()
 		defer o.m.Unlock()
@@ -23,7 +23,7 @@ func (o *targetObserverStub) TargetDiscovered(t DiscoveredTarget) {
 }
 
 // TargetUndiscovered calls o.TargetUndiscoveredFunc(t) if it is non-nil.
-func (o *targetObserverStub) TargetUndiscovered(t DiscoveredTarget) {
+func (o *targetObserverStub) TargetUndiscovered(t *Target) {
 	if o.TargetUndiscoveredFunc != nil {
 		o.m.Lock()
 		defer o.m.Unlock()

--- a/static.go
+++ b/static.go
@@ -4,20 +4,14 @@ import "context"
 
 // StaticDiscoverer is a Discoverer that always "discovers" a fixed set of
 // pre-configured targets.
-type StaticDiscoverer []Target
+type StaticDiscoverer []*Target
 
 // Discover notifies o of targets that are discovered or undiscovered until ctx
 // is canceled or an error occurs.
 func (d StaticDiscoverer) Discover(ctx context.Context, o TargetObserver) error {
 	for _, t := range d {
-		dt := DiscoveredTarget{
-			Target:     t,
-			ID:         DiscoveredTargetID(),
-			Discoverer: d,
-		}
-
-		o.TargetDiscovered(dt)
-		defer o.TargetUndiscovered(dt)
+		o.TargetDiscovered(t)
+		defer o.TargetUndiscovered(t)
 	}
 
 	<-ctx.Done()


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR removes the `DiscoveredTarget` struct, which added information to a `Target` about the `Discoverer` that discovered it.

The `ID` field that was present in `DiscoveredTarget`, used to uniquely identify the target within the current process has been obviated by instead just using a pointer to a target (`*Target`) and using the pointer value itself as the identifier.

#### Why make this change?

- We don't really need this information. If it matters which discoverer found the target there's probably some missing layer of configuration or coupling that should not be present.
- The `ID` was a bit over complicated, a pointer is already uniquely identifies a value in-process.
- It simplifies a bunch of things.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Partially addresses #1.
