### PR TITLE
Use a "blocking observer" in discoverers.

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -1,17 +1,17 @@
 package discoverkit
 
 import (
-	"sync"
+	"context"
 
 	"google.golang.org/grpc"
 )
 
-// Connector is a TargetObserver implementation that dials each discovered
-// target and notifies a ConnectionObserver when connections become available or
+// Connector is a DiscoverObserver implementation that dials each discovered
+// target and notifies a ConnectObserver when connections become available or
 // unavailable.
 type Connector struct {
 	// Observer is the observer to notify about gRPC connections.
-	Observer ConnectionObserver
+	Observer ConnectObserver
 
 	// Dial is the function used to dial gRPC targets.
 	//
@@ -29,28 +29,16 @@ type Connector struct {
 	// notified about them.
 	//
 	// If it is nil, no targets are ignored.
-	Ignore func(*Target) bool
-
-	// OnDialError is a function that is called when a call to Dial() fails.
-	//
-	// Typically dialing only fails if there's some problem with the dial
-	// options. By default, underlying connection is established lazily *after*
-	// the dialer returns.
-	//
-	// If it is nil, dialing errors are silently ignored.
-	OnDialError func(*Target, error)
-
-	m           sync.Mutex
-	connections map[*Target]*grpc.ClientConn
+	Ignore func(Target) bool
 }
 
-// TargetDiscovered is called when a discoverer becomes aware of a target.
+// TargetDiscovered is called when a new target is discovered.
 //
-// It attempts to dial the target and if successful it notifies the observer of
-// the new connection.
-func (c *Connector) TargetDiscovered(t *Target) {
+// ctx is canceled if the target is undiscovered while TargetDiscovered() is
+// still executing.
+func (c *Connector) TargetDiscovered(ctx context.Context, t Target) error {
 	if c.Ignore != nil && c.Ignore(t) {
-		return
+		return nil
 	}
 
 	dial := c.Dial
@@ -62,55 +50,22 @@ func (c *Connector) TargetDiscovered(t *Target) {
 	options = append(options, c.DialOptions...)
 	options = append(options, t.DialOptions...)
 
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	if c.connections == nil {
-		c.connections = map[*Target]*grpc.ClientConn{}
-	} else if _, ok := c.connections[t]; ok {
-		// This target has already been discovered. This should never occur but
-		// is added to account for misbehaving Discoverer implementations.
-		return
-	}
-
 	conn, err := dial(t.Name, options...)
 	if err != nil {
-		if c.OnDialError != nil {
-			c.OnDialError(t, err)
-		}
-
-		return
+		return err
 	}
+	defer conn.Close()
 
-	c.connections[t] = conn
-	c.Observer.ConnectionAvailable(t, conn)
+	return c.Observer.TargetConnected(ctx, t, conn)
 }
 
-// TargetUndiscovered is called when a previously discovered target is no longer
-// considered to exist.
-//
-// If a connection has been dialed for this target the observer is first
-// notified that the connection is no longer available and then the connection
-// is closed.
-func (c *Connector) TargetUndiscovered(t *Target) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	if conn, ok := c.connections[t]; ok {
-		delete(c.connections, t)
-		c.Observer.ConnectionUnavailable(t, conn)
-		conn.Close()
-	}
-}
-
-// ConnectionObserver is notified when a connection to a target becomes
-// available or unavailable.
-type ConnectionObserver interface {
-	// ConnectionAvailable is called when a connection to a target becomes
-	// available.
-	ConnectionAvailable(*Target, grpc.ClientConnInterface)
-
-	// ConnectionUnavailable is called when a connection to a target becomes
-	// unavailable.
-	ConnectionUnavailable(*Target, grpc.ClientConnInterface)
+// ConnectObserver is an interface for handling new target connections.
+type ConnectObserver interface {
+	// TargetConnected is called when a new connection is established.
+	//
+	// ctx is canceled if the target is undiscovered while TargetConnected() is
+	// still executed.
+	//
+	// The connection is automatically closed when TargetConnected() returns.
+	TargetConnected(ctx context.Context, t Target, conn grpc.ClientConnInterface) error
 }

--- a/connector.go
+++ b/connector.go
@@ -29,7 +29,7 @@ type Connector struct {
 	// notified about them.
 	//
 	// If it is nil, no targets are ignored.
-	Ignore func(Target) bool
+	Ignore func(context.Context, Target) (bool, error)
 }
 
 // TargetDiscovered is called when a new target is discovered.
@@ -37,8 +37,11 @@ type Connector struct {
 // ctx is canceled if the target is undiscovered while TargetDiscovered() is
 // still executing.
 func (c *Connector) TargetDiscovered(ctx context.Context, t Target) error {
-	if c.Ignore != nil && c.Ignore(t) {
-		return nil
+	if c.Ignore != nil {
+		ignore, err := c.Ignore(ctx, t)
+		if ignore || err != nil {
+			return err
+		}
 	}
 
 	dial := c.Dial

--- a/connector_test.go
+++ b/connector_test.go
@@ -60,8 +60,11 @@ var _ = Describe("type Connector", func() {
 
 		When("there is an ignore predicate", func() {
 			BeforeEach(func() {
-				connector.Ignore = func(t Target) bool {
-					return t.Name == target1.Name
+				connector.Ignore = func(
+					_ context.Context,
+					t Target,
+				) (bool, error) {
+					return t.Name == target1.Name, nil
 				}
 			})
 
@@ -95,6 +98,21 @@ var _ = Describe("type Connector", func() {
 					target1,
 				)
 				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("returns the error produced by the ignore predicate", func() {
+				connector.Ignore = func(
+					_ context.Context,
+					t Target,
+				) (bool, error) {
+					return false, errors.New("<error>")
+				}
+
+				err := connector.TargetDiscovered(
+					context.Background(),
+					target1,
+				)
+				Expect(err).To(MatchError("<error>"))
 			})
 		})
 

--- a/discoverer.go
+++ b/discoverer.go
@@ -2,27 +2,49 @@ package discoverkit
 
 import (
 	"context"
+	"fmt"
 )
 
 // Discoverer is an interface for services that discover gRPC Targets.
 type Discoverer interface {
-	// Discover notifies o of targets that are discovered or undiscovered
-	// until ctx is canceled or an error occurs.
-	Discover(ctx context.Context, o TargetObserver) error
+	// Discover invokes o.TargetDiscovered() when a new target is discovered.
+	//
+	// Each invocation is made on its own goroutine. The context passed to
+	// o.TargetDiscovered() is canceled when the target is "undiscovered", or
+	// the discoverer itself is stopped due to cancelation of ctx.
+	//
+	// The discoverer stops and returns a DiscoverObserverError if any call to
+	// o.TargetDiscovered() returns a non-nil error.
+	Discover(ctx context.Context, o DiscoverObserver) error
 }
 
-// TargetObserver is notified when a target is discovered or undiscovered.
-type TargetObserver interface {
-	// TargetDiscovered is called when a discoverer becomes aware of a target.
+// DiscoverObserver is an interface for types that accept notifications about
+// target discovery.
+type DiscoverObserver interface {
+	// TargetDiscovered is called when a new target is discovered.
 	//
-	// The target is not necessarily online, or if it is online, not necessarily
-	// available to serve requests.
-	TargetDiscovered(*Target)
+	// ctx is canceled if the target is undiscovered while TargetDiscovered() is
+	// still executing.
+	TargetDiscovered(ctx context.Context, t Target) error
+}
 
-	// TargetUndiscovered is called when a previously discovered target is no
-	// longer considered to exist.
-	//
-	// t must have previously been passed to TargetDiscovered. That is, the
-	// pointer address itself.
-	TargetUndiscovered(*Target)
+// DiscoverObserverError indicates that a discoverer was stopped because a
+// DiscoverObserver produced an error.
+type DiscoverObserverError struct {
+	Discoverer Discoverer
+	Observer   DiscoverObserver
+	Target     Target
+	Cause      error
+}
+
+func (e DiscoverObserverError) Unwrap() error {
+	return e.Cause
+}
+
+func (e DiscoverObserverError) Error() string {
+	return fmt.Sprintf(
+		"observing %s target: %s",
+		e.Target.Name,
+		e.Cause,
+	)
 }

--- a/discoverer.go
+++ b/discoverer.go
@@ -18,8 +18,7 @@ type Discoverer interface {
 	Discover(ctx context.Context, o DiscoverObserver) error
 }
 
-// DiscoverObserver is an interface for types that accept notifications about
-// target discovery.
+// DiscoverObserver is an interface for handling the discovery of a target.
 type DiscoverObserver interface {
 	// TargetDiscovered is called when a new target is discovered.
 	//

--- a/discoverer_test.go
+++ b/discoverer_test.go
@@ -1,32 +1,21 @@
 package discoverkit_test
 
 import (
-	"sync"
+	"context"
 
 	. "github.com/dogmatiq/discoverkit"
 )
 
-// targetObserverStub is a test implementation of the TargetObserver interface.
-type targetObserverStub struct {
-	m                      sync.Mutex
-	TargetDiscoveredFunc   func(*Target)
-	TargetUndiscoveredFunc func(*Target)
+// discoverObserverStub is a test implementation of the TargetObserver interface.
+type discoverObserverStub struct {
+	TargetDiscoveredFunc func(context.Context, Target) error
 }
 
-// TargetDiscovered calls o.TargetDiscoveredFunc(t) if it is non-nil.
-func (o *targetObserverStub) TargetDiscovered(t *Target) {
+// TargetDiscovered calls o.TargetDiscoveredFunc(ctx, t) if it is non-nil.
+func (o *discoverObserverStub) TargetDiscovered(ctx context.Context, t Target) error {
 	if o.TargetDiscoveredFunc != nil {
-		o.m.Lock()
-		defer o.m.Unlock()
-		o.TargetDiscoveredFunc(t)
+		return o.TargetDiscoveredFunc(ctx, t)
 	}
-}
 
-// TargetUndiscovered calls o.TargetUndiscoveredFunc(t) if it is non-nil.
-func (o *targetObserverStub) TargetUndiscovered(t *Target) {
-	if o.TargetUndiscoveredFunc != nil {
-		o.m.Lock()
-		defer o.m.Unlock()
-		o.TargetUndiscoveredFunc(t)
-	}
+	return nil
 }

--- a/discoverer_test.go
+++ b/discoverer_test.go
@@ -2,9 +2,36 @@ package discoverkit_test
 
 import (
 	"context"
+	"errors"
 
 	. "github.com/dogmatiq/discoverkit"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("type DiscoverObserverError", func() {
+	Describe("func Error()", func() {
+		It("provides context about the target", func() {
+			err := DiscoverObserverError{
+				Target: Target{Name: "<target>"},
+				Cause:  errors.New("<error>"),
+			}
+
+			Expect(err.Error()).To(Equal("failure observing '<target>' target: <error>"))
+		})
+	})
+
+	Describe("func Unwrap()", func() {
+		It("unwraps the causal error", func() {
+			cause := errors.New("<error>")
+			err := DiscoverObserverError{
+				Cause: cause,
+			}
+
+			Expect(errors.Is(err, cause)).To(BeTrue())
+		})
+	})
+})
 
 // discoverObserverStub is a test implementation of the TargetObserver interface.
 type discoverObserverStub struct {

--- a/discoverer_test.go
+++ b/discoverer_test.go
@@ -33,7 +33,8 @@ var _ = Describe("type DiscoverObserverError", func() {
 	})
 })
 
-// discoverObserverStub is a test implementation of the TargetObserver interface.
+// discoverObserverStub is a test implementation of the DiscoverObserver
+// interface.
 type discoverObserverStub struct {
 	TargetDiscoveredFunc func(context.Context, Target) error
 }

--- a/dns.go
+++ b/dns.go
@@ -3,9 +3,11 @@ package discoverkit
 import (
 	"context"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/dogmatiq/linger"
+	"golang.org/x/sync/errgroup"
 )
 
 // DNSResolver is an interface for the subset of net.Resolver used by
@@ -37,7 +39,7 @@ type DNSDiscoverer struct {
 	// If NewTargets is nil the discoverer constructs a single Target for each
 	// discovered address. The target name is the discovered address and no
 	// explicit port is specified.
-	NewTargets func(ctx context.Context, addr string) (targets []*Target, err error)
+	NewTargets func(ctx context.Context, addr string) (targets []Target, err error)
 
 	// Resolver is the DNS resolver used to make queries.
 	//
@@ -49,31 +51,52 @@ type DNSDiscoverer struct {
 	// If it is non-positive, the DefaultDNSQueryInterval constant is used.
 	QueryInterval time.Duration
 
-	// targets is the set of targets currently known to the discoverer.
-	targets map[string][]*Target
+	parent   context.Context
+	group    *errgroup.Group
+	known    map[string]context.CancelFunc
+	observer DiscoverObserver
 }
 
-// Discover notifies o of targets that are discovered or undiscovered until ctx
-// is canceled or an error occurs.
-func (d *DNSDiscoverer) Discover(ctx context.Context, o TargetObserver) error {
-	defer func() {
-		for _, targets := range d.targets {
-			for _, t := range targets {
-				o.TargetUndiscovered(t)
-			}
-		}
-	}()
+// Discover invokes o.TargetDiscovered() when a new target is discovered.
+//
+// Each invocation is made on its own goroutine. The context passed to
+// o.TargetDiscovered() is canceled when the target is "undiscovered", or the
+// discoverer itself is stopped due to cancelation of ctx.
+//
+// The discoverer stops and returns a DiscoverObserverError if any call to
+// o.TargetDiscovered() returns a non-nil error.
+func (d *DNSDiscoverer) Discover(ctx context.Context, o DiscoverObserver) error {
+	d.group, d.parent = errgroup.WithContext(ctx)
+	d.known = map[string]context.CancelFunc{}
+	d.observer = o
 
+	d.group.Go(func() error {
+		// Perform the actual discovery within the same group as the observer
+		// goroutines. This ensures both that Wait() always has something to
+		// wait for, so that it doesn't just return immediately, and that the
+		// whole group is shutdown if the discovery process itself fails.
+		return d.discover(d.parent)
+	})
+
+	return d.group.Wait()
+}
+
+// discover periodically queries the DNS server and starts/stops observer
+// goroutines as necessary.
+func (d *DNSDiscoverer) discover(ctx context.Context) error {
 	for {
-		addrs, err := d.query(ctx)
+		// Perform the DNS query.
+		results, err := d.query(ctx)
 		if err != nil {
 			return err
 		}
 
-		if err := d.update(ctx, addrs, o); err != nil {
+		// Start and stop observer goroutines to match the new results.
+		if err := d.sync(ctx, results); err != nil {
 			return err
 		}
 
+		// Wait until it's time to perform the next DNS query.
 		if err := linger.Sleep(
 			ctx,
 			d.QueryInterval,
@@ -84,59 +107,60 @@ func (d *DNSDiscoverer) Discover(ctx context.Context, o TargetObserver) error {
 	}
 }
 
-// update sends notifications to o about the targets that have become
-// available/unavailable based on new query results.
-func (d *DNSDiscoverer) update(
+// sync synchronizes the state of running observers based on a new set of DNS
+// query results.
+func (d *DNSDiscoverer) sync(
 	ctx context.Context,
-	addrs []string,
-	o TargetObserver,
+	results map[string]struct{},
 ) error {
-	prev := d.targets
-	d.targets = make(map[string][]*Target, len(addrs))
-
-	// Add an entry to d.targets for each of the addresses in the query result.
-	for _, addr := range addrs {
-		if targets, ok := prev[addr]; ok {
-			// We have already discovered this address. It may or may not have
-			// any targets. Either way we retain them unchanged.
-			d.targets[addr] = targets
-			continue
+	// First we check through the known addresses to work out which ones are
+	// still in the latest query results.
+	for addr, cancel := range d.known {
+		if _, ok := results[addr]; ok {
+			// This address is still avaliable. Remove it from the query results
+			// so we're left only with addresses that we have not seen before.
+			delete(results, addr)
+		} else {
+			// This address is no longer available. Cancel the associated
+			// context to stop the observer goroutines.
+			delete(d.known, addr)
+			cancel()
 		}
+	}
 
-		// Otherwise, we're seeing this address for the first time, or it's
-		// reappeared after being removed from the DNS results. We construct the
-		// targets that are at this address.
+	// Then we can look at the query results, which at this point contains only
+	// those addresses we didn't already know about.
+	for addr := range results {
 		targets, err := d.newTargets(ctx, addr)
 		if err != nil {
 			return err
 		}
 
-		// Notify the observer of the targets.
+		// Create a new context specifically for this address. Note that it is
+		// derived directly from d.parent, not ctx (which represents only the
+		// lifetime of this call to the update() method). It will be canceled if
+		// the address dissappears from the query results.
+		addrCtx, cancel := context.WithCancel(d.parent)
+		d.known[addr] = cancel
+
+		// Start a new goroutine for each target.
 		for _, t := range targets {
-			o.TargetDiscovered(t)
-		}
-
-		// Store the discovered targets against the address.
-		// Note that we still store a nil or empty slice against this
-		// address. This ensures that we still treat the address as "seen".
-		d.targets[addr] = targets
-	}
-
-	// Notify the observer of any targets that have gone away because the
-	// address they were based on is no longer in the query results.
-	for a, targets := range prev {
-		if _, ok := d.targets[a]; !ok {
-			for _, dt := range targets {
-				o.TargetUndiscovered(dt)
-			}
+			t := t // capture loop variable
+			d.group.Go(func() error {
+				return targetDiscovered(addrCtx, d, d.observer, t)
+			})
 		}
 	}
 
 	return nil
 }
 
-// query performs a DNS query to find API targets.
-func (d *DNSDiscoverer) query(ctx context.Context) ([]string, error) {
+// query performs a DNS query to A, AAAA and CNAME records associated with
+// d.QueryHost.
+//
+// It returns the resulting addresses as a set with names transformed to
+// lowercase. Individual addresses may be hostnames or IP addresses.
+func (d *DNSDiscoverer) query(ctx context.Context) (map[string]struct{}, error) {
 	r := d.Resolver
 	if r == nil {
 		r = net.DefaultResolver
@@ -145,6 +169,8 @@ func (d *DNSDiscoverer) query(ctx context.Context) ([]string, error) {
 	addrs, err := r.LookupHost(ctx, d.QueryHost)
 	if err != nil {
 		if x, ok := err.(*net.DNSError); ok {
+			// Temporary network problems, or the fact that host doesn't exist
+			// *right now* are not errors that should stop the discoverer.
 			if x.IsTemporary || x.IsNotFound {
 				return nil, nil
 			}
@@ -153,16 +179,22 @@ func (d *DNSDiscoverer) query(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	return addrs, nil
+	// Convert the slice of addresses to a set of lowercase strings.
+	results := make(map[string]struct{}, len(addrs))
+	for _, addr := range addrs {
+		results[strings.ToLower(addr)] = struct{}{}
+	}
+
+	return results, err
 }
 
 // newTarget returns the targets at the given address.
-func (d *DNSDiscoverer) newTargets(ctx context.Context, addr string) ([]*Target, error) {
+func (d *DNSDiscoverer) newTargets(ctx context.Context, addr string) ([]Target, error) {
 	if d.NewTargets != nil {
 		return d.NewTargets(ctx, addr)
 	}
 
-	return []*Target{
+	return []Target{
 		{Name: addr},
 	}, nil
 }

--- a/dns_test.go
+++ b/dns_test.go
@@ -3,7 +3,10 @@ package discoverkit_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/dogmatiq/discoverkit"
@@ -15,7 +18,7 @@ var _ = Describe("type DNSDiscoverer", func() {
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc
-		obs    *targetObserverStub
+		obs    *discoverObserverStub
 		res    *dnsResolverStub
 		disc   *DNSDiscoverer
 	)
@@ -24,7 +27,7 @@ var _ = Describe("type DNSDiscoverer", func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 		ctx, cancel = context.WithCancel(ctx)
 
-		obs = &targetObserverStub{}
+		obs = &discoverObserverStub{}
 
 		res = &dnsResolverStub{}
 
@@ -39,7 +42,7 @@ var _ = Describe("type DNSDiscoverer", func() {
 	})
 
 	Describe("func Discover()", func() {
-		It("notifies the observer of discovery when addresses are found", func() {
+		It("invokes the observer when a target is discovered", func() {
 			res.LookupHostFunc = func(_ context.Context, host string) ([]string, error) {
 				cancel()
 
@@ -47,20 +50,31 @@ var _ = Describe("type DNSDiscoverer", func() {
 				return []string{"<addr-1>", "<addr-2>"}, nil
 			}
 
-			var targets []*Target
-			obs.TargetDiscoveredFunc = func(t *Target) {
+			var (
+				m       sync.Mutex
+				targets []Target
+			)
+
+			obs.TargetDiscoveredFunc = func(
+				_ context.Context,
+				t Target,
+			) error {
+				m.Lock()
 				targets = append(targets, t)
+				m.Unlock()
+
+				return nil
 			}
 
 			err := disc.Discover(ctx, obs)
 			Expect(err).To(Equal(context.Canceled))
 			Expect(targets).To(ConsistOf(
-				&Target{Name: "<addr-1>"},
-				&Target{Name: "<addr-2>"},
+				Target{Name: "<addr-1>"},
+				Target{Name: "<addr-2>"},
 			))
 		})
 
-		It("notifies the observer of undiscovery when addresses go away", func() {
+		It("cancels the observer context when a target goes away", func() {
 			disc.QueryInterval = 10 * time.Millisecond
 
 			res.LookupHostFunc = func(context.Context, string) ([]string, error) {
@@ -73,23 +87,58 @@ var _ = Describe("type DNSDiscoverer", func() {
 				return []string{"<addr-1>", "<addr-2>"}, nil
 			}
 
-			obs.TargetUndiscoveredFunc = func(t *Target) {
-				Expect(t).To(Equal(
-					&Target{Name: "<addr-1>"},
-				))
+			ok := make(chan struct{})
 
-				// Remove this function from the stub to prevent a failure when
-				// <addr-2> becomes unavailable when the discover is stopped.
-				obs.TargetUndiscoveredFunc = nil
+			obs.TargetDiscoveredFunc = func(
+				targetCtx context.Context,
+				t Target,
+			) error {
+				<-targetCtx.Done()
 
-				cancel()
+				// We expect "<addr-1>" to be "undiscovered" based on the setup
+				// of res.LookupHostFunc above.
+				if t.Name == "<addr-1>" {
+					close(ok)
+					return nil
+				}
+
+				// Otherwise we would expect only to be canceled when the
+				// discover is stopped by cancelling the parent context.
+				if ctx.Err() == nil {
+					return fmt.Errorf("unexpected cancelation for %s", t.Name)
+				}
+
+				return nil
 			}
 
-			err := disc.Discover(ctx, obs)
+			result := make(chan error, 1)
+			go func() {
+				result <- disc.Discover(ctx, obs)
+			}()
+
+			select {
+			case <-ok:
+				// We expect the "ok" channel to be closed when the context
+				// associated with "<addr-1>" is canceled.
+				cancel() // stop the discoverer
+
+			case err := <-result:
+				// We don't expect the discoverer to stop before "ok" is closed.
+				Expect(err).ShouldNot(HaveOccurred(), "discoverer stopped prematurely")
+
+			case <-ctx.Done():
+				// We don't expect the parent context to be canceled before "ok"
+				// is closed.
+				Expect(ctx.Err()).ShouldNot(HaveOccurred(), "context canceled prematurely")
+			}
+
+			// Now that we called cancel() we expect the discoverer to stop in a
+			// timely manner.
+			err := <-result
 			Expect(err).To(Equal(context.Canceled))
 		})
 
-		It("notifies the observer of undiscovery when the discoverer is stopped", func() {
+		It("cancels the context passed to the observer when the discoverer is stopped", func() {
 			disc.QueryInterval = 10 * time.Millisecond
 
 			res.LookupHostFunc = func(context.Context, string) ([]string, error) {
@@ -97,28 +146,36 @@ var _ = Describe("type DNSDiscoverer", func() {
 				return []string{"<addr-1>", "<addr-2>"}, nil
 			}
 
-			targets := map[*Target]struct{}{}
+			var running int32 // atomic
 
-			obs.TargetDiscoveredFunc = func(t *Target) {
-				targets[t] = struct{}{}
-			}
+			obs.TargetDiscoveredFunc = func(
+				ctx context.Context,
+				_ Target,
+			) error {
+				n := atomic.AddInt32(&running, 1)
+				defer atomic.AddInt32(&running, -1)
 
-			obs.TargetUndiscoveredFunc = func(t *Target) {
-				_, ok := targets[t]
-				Expect(ok).To(BeTrue())
-				delete(targets, t)
+				if int(n) == 2 {
+					go cancel()
+				}
+
+				<-ctx.Done()
+				return ctx.Err()
 			}
 
 			err := disc.Discover(ctx, obs)
 			Expect(err).To(Equal(context.Canceled))
-			Expect(targets).To(BeEmpty())
+			Expect(atomic.LoadInt32(&running)).To(BeZero())
 		})
 
 		It("uses net.DefaultResolver by default", func() {
 			disc.QueryHost = "localhost"
 			disc.Resolver = nil
 
-			obs.TargetDiscoveredFunc = func(t *Target) {
+			obs.TargetDiscoveredFunc = func(
+				_ context.Context,
+				t Target,
+			) error {
 				cancel()
 
 				Expect(t.Name).To(
@@ -127,6 +184,8 @@ var _ = Describe("type DNSDiscoverer", func() {
 						Equal("::1"),
 					),
 				)
+
+				return nil
 			}
 
 			err := disc.Discover(ctx, obs)
@@ -135,8 +194,8 @@ var _ = Describe("type DNSDiscoverer", func() {
 
 		When("there is a NewTargets() function", func() {
 			It("uses the targets returned by NewTargets()", func() {
-				disc.NewTargets = func(_ context.Context, addr string) ([]*Target, error) {
-					return []*Target{
+				disc.NewTargets = func(_ context.Context, addr string) ([]Target, error) {
+					return []Target{
 						{Name: addr + "-A"},
 						{Name: addr + "-B"},
 					}, nil
@@ -147,30 +206,40 @@ var _ = Describe("type DNSDiscoverer", func() {
 					return []string{"<addr-1>", "<addr-2>"}, nil
 				}
 
-				var targets []*Target
-				obs.TargetDiscoveredFunc = func(t *Target) {
+				var (
+					m       sync.Mutex
+					targets []Target
+				)
+
+				obs.TargetDiscoveredFunc = func(
+					_ context.Context,
+					t Target,
+				) error {
+					m.Lock()
 					targets = append(targets, t)
+					m.Unlock()
+
+					return nil
 				}
 
 				err := disc.Discover(ctx, obs)
 				Expect(err).To(Equal(context.Canceled))
 				Expect(targets).To(ConsistOf(
-					&Target{Name: "<addr-1>-A"},
-					&Target{Name: "<addr-1>-B"},
-					&Target{Name: "<addr-2>-A"},
-					&Target{Name: "<addr-2>-B"},
+					Target{Name: "<addr-1>-A"},
+					Target{Name: "<addr-1>-B"},
+					Target{Name: "<addr-2>-A"},
+					Target{Name: "<addr-2>-B"},
 				))
 			})
 
-			It("properly tracks addresses for which NewTargets() returns an empty slice", func() {
+			It("does not call NewTargets() again for an address that already produced zero targets", func() {
 				disc.QueryInterval = 10 * time.Millisecond
 
-				disc.NewTargets = func(context.Context, string) ([]*Target, error) {
+				disc.NewTargets = func(context.Context, string) ([]Target, error) {
 					// Replace this function on the stub to ensure that it
 					// doesn't get called again for the same address.
-					disc.NewTargets = func(context.Context, string) ([]*Target, error) {
-						Fail("unexpected second invocation of NewTargets()")
-						return nil, nil
+					disc.NewTargets = func(context.Context, string) ([]Target, error) {
+						return nil, errors.New("unexpected second invocation of NewTargets()")
 					}
 
 					return nil, nil
@@ -192,8 +261,11 @@ var _ = Describe("type DNSDiscoverer", func() {
 					return []string{"<addr>"}, nil
 				}
 
-				obs.TargetDiscoveredFunc = func(*Target) {
-					Fail("unexpoected notification of discovered target")
+				obs.TargetDiscoveredFunc = func(
+					context.Context,
+					Target,
+				) error {
+					return errors.New("unexpoected notification of discovered target")
 				}
 
 				err := disc.Discover(ctx, obs)
@@ -201,7 +273,7 @@ var _ = Describe("type DNSDiscoverer", func() {
 			})
 
 			It("returns an error if NewTargets() returns an error", func() {
-				disc.NewTargets = func(context.Context, string) ([]*Target, error) {
+				disc.NewTargets = func(context.Context, string) ([]Target, error) {
 					return nil, errors.New("<error>")
 				}
 
@@ -214,8 +286,8 @@ var _ = Describe("type DNSDiscoverer", func() {
 			})
 		})
 
-		When("the resolver fails", func() {
-			It("does not propagate not-found errors", func() {
+		When("the resolver returns an error", func() {
+			It("ignores not-found errors", func() {
 				res.LookupHostFunc = func(context.Context, string) ([]string, error) {
 					cancel()
 					return nil, &net.DNSError{
@@ -227,7 +299,7 @@ var _ = Describe("type DNSDiscoverer", func() {
 				Expect(err).To(Equal(context.Canceled)) // note: not the net.DNSError
 			})
 
-			It("propagates other errors", func() {
+			It("returns other errors", func() {
 				res.LookupHostFunc = func(context.Context, string) ([]string, error) {
 					return nil, errors.New("<error>")
 				}

--- a/dns_test.go
+++ b/dns_test.go
@@ -265,7 +265,7 @@ var _ = Describe("type DNSDiscoverer", func() {
 					context.Context,
 					Target,
 				) error {
-					return errors.New("unexpoected notification of discovered target")
+					return errors.New("unexpected call to TargetDiscovered()")
 				}
 
 				err := disc.Discover(ctx, obs)

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/dogmatiq/linger v0.2.1
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.4
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	google.golang.org/grpc v1.34.0
 )

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/static.go
+++ b/static.go
@@ -1,19 +1,40 @@
 package discoverkit
 
-import "context"
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
 
 // StaticDiscoverer is a Discoverer that always "discovers" a fixed set of
 // pre-configured targets.
-type StaticDiscoverer []*Target
+type StaticDiscoverer []Target
 
-// Discover notifies o of targets that are discovered or undiscovered until ctx
-// is canceled or an error occurs.
-func (d StaticDiscoverer) Discover(ctx context.Context, o TargetObserver) error {
+// Discover invokes o.TargetDiscovered() when a new target is discovered.
+//
+// Each invocation is made on its own goroutine. The context passed to
+// o.TargetDiscovered() is canceled when the target is "undiscovered", or the
+// discoverer itself is stopped due to cancelation of ctx.
+//
+// The discoverer stops and returns a DiscoverObserverError if any call to
+// o.TargetDiscovered() returns a non-nil error.
+func (d StaticDiscoverer) Discover(ctx context.Context, o DiscoverObserver) error {
+	g, ctx := errgroup.WithContext(ctx)
+
 	for _, t := range d {
-		o.TargetDiscovered(t)
-		defer o.TargetUndiscovered(t)
+		t := t // capture loop variable
+
+		g.Go(func() error {
+			return targetDiscovered(ctx, d, o, t)
+		})
 	}
 
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// All of the observer calls have returned successfully so there's nothing
+	// left to do except wait until ctx is canceled.
 	<-ctx.Done()
 	return ctx.Err()
 }


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR replaces the "two method" `TargetObserver` interface with the "one method" `DiscoverObserver` interface and changes the semantics of notifying the observer to be "blocking". 

The `DiscoverObserver.TargetDiscovered()` method is run on its own goroutine for each target and may block for as long as necessary. 

When a target goes away the engine cancels the context that was passed to `TargetDiscovered()` rather than calling the `TargetUndiscovered()` method (which no longer exists).

#### Why make this change?

- It allows observers to propagate errors back to the discoverer.
- It allows observers to "finish early" by returning a `nil` error, which in turn allows the discoverer to free any state associated with that target.
- It allows us to revert to passing `Target` by value instead of as a pointer, as we no longer need to correlate targets on discovery/undiscovery.

The discovery implementation in `dogmatiq/configkit` supported a similar "call-with-context-cancellation" approach built on top of the "two method" observer interfaces. In practice the engine's always used the "call-with-context-cancellation" approach so In the interest of simplicity I thought it was better to just have the system work this way natively.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

#1
