### PR TITLE
Implement application discovery.

### DIFF
--- a/application.go
+++ b/application.go
@@ -55,7 +55,7 @@ func (e ApplicationObserverError) Error() string {
 	)
 }
 
-// ApplicationDiscoverer is an service for discovers Dogma applications running
+// ApplicationDiscoverer is a service that discovers Dogma applications running
 // on gRPC targets.
 //
 // It implements ConnectObserver and forwards to an ApplicationObserver.
@@ -205,7 +205,6 @@ func (d *ApplicationDiscoverer) recv(
 			// This approach is taken (as opposed to returning the error) so
 			// that we can continue to use other applications with well-formed
 			// identities on the same server.
-
 			if d.LogError != nil {
 				err = fmt.Errorf("invalid application identity: %w", err)
 				d.LogError(c, err)

--- a/application.go
+++ b/application.go
@@ -1,0 +1,284 @@
+package discoverkit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/interopspec/discoverspec"
+	"github.com/dogmatiq/linger/backoff"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Application is a Dogma application that was discovered on a Target.
+type Application struct {
+	// Identity is the application's identity.
+	Identity configkit.Identity
+
+	// Connection is the connection that was used to discover the application.
+	Connection Connection
+}
+
+// ApplicationObserver is an interface for handling the discovery of Dogma
+// applications.
+type ApplicationObserver interface {
+	// ApplicationDiscovered is called when a new application becomes available.
+	//
+	// ctx is canceled if the application becomes unavailable while
+	// ApplicationDiscovered() is still executing.
+	//
+	// Note that it is possible for a single application identity to be
+	// available via several connections.
+	ApplicationDiscovered(ctx context.Context, a Application) error
+}
+
+// ApplicationObserverError indicates that an application discoverer was stopped
+// because an ApplicationObserver produced an error.
+type ApplicationObserverError struct {
+	Discoverer  *ApplicationDiscoverer
+	Observer    ApplicationObserver
+	Application Application
+	Cause       error
+}
+
+func (e ApplicationObserverError) Unwrap() error {
+	return e.Cause
+}
+
+func (e ApplicationObserverError) Error() string {
+	return fmt.Sprintf(
+		"failure observing '%s' application: %s",
+		e.Application.Identity,
+		e.Cause,
+	)
+}
+
+// ApplicationDiscoverer is an service for discovers Dogma applications running
+// on gRPC targets.
+//
+// It implements ConnectObserver and forwards to an ApplicationObserver.
+//
+// It discovers applications on gRPC targets that implement the DiscoverAPI as
+// defined in github.com/dogmatiq/interopspec/discoverspec. An implementation of
+// this API is provided by the discoverkit.Server type.
+type ApplicationDiscoverer struct {
+	// Observer is the observer that is invoked when an application becomes
+	// available.
+	Observer ApplicationObserver
+
+	// BackoffStrategy is the strategy that determines when to retry watching a
+	// gRPC target for application availability changes.
+	BackoffStrategy backoff.Strategy
+
+	// LogError is an optional function that logs errors that occur while
+	// attempting to watch a gRPC target.
+	LogError func(Connection, error)
+}
+
+// TargetConnected is called when a new connection is established.
+//
+// ctx is canceled if the target becomes unavailable while TargetConnected() is
+// still executing.
+//
+// The connection is automatically closed when TargetConnected() returns.
+//
+// It returns nil if the gRPC target does not implement the DiscoverAPI.
+func (d *ApplicationDiscoverer) TargetConnected(ctx context.Context, c Connection) error {
+	ctr := &backoff.Counter{
+		Strategy: d.BackoffStrategy,
+	}
+
+	for {
+		// Attempt to discover applications via the given connection.
+		err := d.watch(ctx, c, ctr)
+
+		// If the error is nil it means that the target does not implement the
+		// DiscoverAPI. This is not an error, it simply means that we will never
+		// discover any application on this target.
+		if err == nil {
+			return nil
+		}
+
+		// If the observer caused the failure we report that.
+		if _, ok := err.(ApplicationObserverError); ok {
+			return err
+		}
+
+		if d.LogError != nil {
+			// If the parent context has been canceled we don't really want to
+			// log about that, so we just bail early.
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			d.LogError(c, err)
+		}
+
+		// Finally, we sleep using the backoff counter until it's time to try
+		// watching again.
+		if err := ctr.Sleep(ctx, err); err != nil {
+			return err
+		}
+	}
+}
+
+var emptyWatchApplicationsRequest discoverspec.WatchApplicationsRequest
+
+// watch starts watching the server for announcements about application
+// availability.
+func (d *ApplicationDiscoverer) watch(
+	ctx context.Context,
+	c Connection,
+	ctr *backoff.Counter,
+) error {
+	// Create a cancellable context specifically to abort the gRPC stream when
+	// this watch attempt is completed.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := discoverspec.
+		NewDiscoverAPIClient(c).
+		WatchApplications(ctx, &emptyWatchApplicationsRequest)
+	if err != nil {
+		// Note that the gRPC package does NOT report "unimplemented" errors
+		// here, even though this is where we call the RPC. Instead, they are
+		// delivered on the first call to stream.Recv().
+		return fmt.Errorf("unable to watch target: %w", err)
+	}
+
+	// Reset the backoff counter now that we've made a successful call to the
+	// server. We expect at this point that the emptyWatchApplicationsRequest
+	// has at least been sent successfully, even though we don't see its result
+	// until we call stream.Recv().
+	ctr.Reset()
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		// Read the stream within the same group as the observer goroutines.
+		// This ensures both that Wait() always has something to wait for, so
+		// that it doesn't just return immediately, and that the whole group is
+		// shutdown if the reading process itself fails.
+		return d.recv(ctx, stream, c, g)
+	})
+
+	<-ctx.Done()
+
+	return g.Wait()
+}
+
+// recv waits for the next message on the stream and starts/stops
+// application-specific observer goroutines as necessary.
+func (d *ApplicationDiscoverer) recv(
+	ctx context.Context,
+	stream discoverspec.DiscoverAPI_WatchApplicationsClient,
+	c Connection,
+	g *errgroup.Group,
+) error {
+	known := map[configkit.Identity]context.CancelFunc{}
+
+	for {
+		res, err := stream.Recv()
+		if err != nil {
+			// If the error indicates that the DiscoverAPI has not been
+			// implemented we return without an error to indicate there's
+			// nothing more to be done.
+			if st, ok := status.FromError(err); ok {
+				if st.Code() == codes.Unimplemented {
+					return nil
+				}
+			}
+
+			return fmt.Errorf("unable to read from stream: %w", err)
+		}
+
+		id, err := configkit.NewIdentity(
+			res.GetIdentity().GetName(),
+			res.GetIdentity().GetKey(),
+		)
+		if err != nil {
+			// The server has sent an invalid application identity. We log about
+			// it if necessary but otherwise ignore the error.
+			//
+			// This approach is taken (as opposed to returning the error) so
+			// that we can continue to use other applications with well-formed
+			// identities on the same server.
+
+			if d.LogError != nil {
+				err = fmt.Errorf("invalid application identity: %w", err)
+				d.LogError(c, err)
+			}
+
+			continue
+		}
+
+		cancel, available := known[id]
+
+		if res.Available == available {
+			// There has been no change in availability. Perhaps the server
+			// re-announced the same application. This is not the *expected*
+			// behavior, but we are lenient in the interest of robustness.
+			continue
+		}
+
+		if !res.Available {
+			// The application has been marked as unavailable. Cancel its
+			// goroutine and remove it from the list of known applications.
+			cancel()
+			delete(known, id)
+			continue
+		}
+
+		// Create a context specific for this application so that we can cancel it
+		// if we receive an unavailable announcement just for this application.
+		appCtx, cancel := context.WithCancel(ctx)
+		known[id] = cancel
+
+		// Start a new goroutine for the application.
+		g.Go(func() error {
+			defer cancel()
+			return applicationDiscovered(
+				appCtx,
+				d,
+				d.Observer,
+				Application{
+					Identity:   id,
+					Connection: c,
+				},
+			)
+		})
+	}
+}
+
+// applicationDiscovered calls o.ApplicationDiscovered().
+//
+// If o.ApplicationDiscovered() returns a non-nil error it returns an
+// ApplicationObserverError.
+//
+// If o.ApplicationDiscovered() returns a context.Canceled error *and* ctx is
+// canceled, it returns nil.
+func applicationDiscovered(
+	ctx context.Context,
+	d *ApplicationDiscoverer,
+	o ApplicationObserver,
+	a Application,
+) error {
+	err := o.ApplicationDiscovered(ctx, a)
+
+	if err == nil {
+		return nil
+	}
+
+	if err == context.Canceled && ctx.Err() == context.Canceled {
+		return nil
+	}
+
+	return ApplicationObserverError{
+		Discoverer:  d,
+		Observer:    o,
+		Application: a,
+		Cause:       err,
+	}
+}

--- a/application_test.go
+++ b/application_test.go
@@ -1,0 +1,444 @@
+package discoverkit_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/dogmatiq/configkit"
+	. "github.com/dogmatiq/discoverkit"
+	"github.com/dogmatiq/interopspec/discoverspec"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+)
+
+var _ = Describe("type ApplicationObserverError", func() {
+	Describe("func Error()", func() {
+		It("provides context about the application", func() {
+			err := ApplicationObserverError{
+				Application: Application{
+					Identity: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+				},
+				Cause: errors.New("<error>"),
+			}
+
+			Expect(err.Error()).To(Equal("failure observing '<app-name>/<app-key>' application: <error>"))
+		})
+	})
+
+	Describe("func Unwrap()", func() {
+		It("unwraps the causal error", func() {
+			cause := errors.New("<error>")
+			err := ApplicationObserverError{
+				Cause: cause,
+			}
+
+			Expect(errors.Is(err, cause)).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("type ApplicationDiscoverer", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+
+		server    *serverStub
+		listener  net.Listener
+		gserver   *grpc.Server
+		target    Target
+		gconn     *grpc.ClientConn
+		conn      Connection
+		responses chan *discoverspec.WatchApplicationsResponse
+
+		obs        *applicationObserverStub
+		discoverer *ApplicationDiscoverer
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 200*time.Millisecond)
+
+		responses = make(chan *discoverspec.WatchApplicationsResponse)
+
+		server = &serverStub{
+			WatchApplicationsFunc: func(
+				_ *discoverspec.WatchApplicationsRequest,
+				stream discoverspec.DiscoverAPI_WatchApplicationsServer,
+			) error {
+				for {
+					select {
+					case <-stream.Context().Done():
+						return nil
+					case r, ok := <-responses:
+						if !ok {
+							return nil
+						}
+
+						if err := stream.Send(r); err != nil {
+							return err
+						}
+					}
+				}
+			},
+		}
+
+		var err error
+		listener, err = net.Listen("tcp", ":")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		gserver = grpc.NewServer()
+
+		target = Target{
+			Name: listener.Addr().String(),
+			DialOptions: []grpc.DialOption{
+				grpc.WithInsecure(),
+			},
+		}
+
+		gconn, err = grpc.Dial(target.Name, target.DialOptions...)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		conn = Connection{
+			ClientConnInterface: gconn,
+			Target:              target,
+		}
+
+		obs = &applicationObserverStub{}
+
+		discoverer = &ApplicationDiscoverer{
+			Observer: obs,
+		}
+	})
+
+	AfterEach(func() {
+		cancel()
+
+		if gconn != nil {
+			gconn.Close()
+		}
+
+		if gserver != nil {
+			gserver.Stop()
+		}
+
+		if listener != nil {
+			listener.Close()
+		}
+	})
+
+	Describe("func TargetConnected()", func() {
+		When("the server implements the discovery API", func() {
+			BeforeEach(func() {
+				discoverspec.RegisterDiscoverAPIServer(gserver, server)
+				go gserver.Serve(listener)
+			})
+
+			When("an app becomes available", func() {
+				BeforeEach(func() {
+					go func() {
+						res := &discoverspec.WatchApplicationsResponse{
+							Identity: &discoverspec.Identity{
+								Name: "<app-name>",
+								Key:  "<app-key>",
+							},
+							Available: true,
+						}
+
+						select {
+						case <-ctx.Done():
+						case responses <- res:
+						}
+					}()
+				})
+
+				It("invokes the observer", func() {
+					obs.ApplicationDiscoveredFunc = func(
+						_ context.Context,
+						app Application,
+					) error {
+						defer cancel()
+						defer GinkgoRecover()
+
+						Expect(app).To(Equal(
+							Application{
+								Identity:   configkit.MustNewIdentity("<app-name>", "<app-key>"),
+								Connection: conn,
+							},
+						))
+
+						return nil
+					}
+
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(context.Canceled))
+				})
+
+				It("returns an error when the observer returns an error", func() {
+					cause := errors.New("<error>")
+
+					obs.ApplicationDiscoveredFunc = func(
+						context.Context,
+						Application,
+					) error {
+						return cause
+					}
+
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(
+						ApplicationObserverError{
+							Discoverer: discoverer,
+							Observer:   obs,
+							Application: Application{
+								Identity:   configkit.MustNewIdentity("<app-name>", "<app-key>"),
+								Connection: conn,
+							},
+							Cause: cause,
+						},
+					))
+				})
+
+				It("cancels the observer context when the server goes offline", func() {
+					obs.ApplicationDiscoveredFunc = func(
+						ctx context.Context,
+						a Application,
+					) error {
+						// Stop the gRPC server.
+						gserver.Stop()
+
+						// Then wait for the application-specific context to be
+						// done, either because it's canceled properly, or
+						// because the test times out.
+						<-ctx.Done()
+
+						// Then we cancel the test's context. If everything is
+						// behaving correctly this should happen BEFORE the test
+						// times out, so we see a context.Canceled error and not
+						// DeadlineExceeded.
+						cancel()
+
+						return ctx.Err()
+					}
+
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(context.Canceled))
+				})
+
+				It("cancels the observer context when the application becomes unavailable", func() {
+					obs.ApplicationDiscoveredFunc = func(
+						ctx context.Context,
+						app Application,
+					) error {
+						// Write the "unavailable" response.
+						res := &discoverspec.WatchApplicationsResponse{
+							Identity: &discoverspec.Identity{
+								Name: app.Identity.Name,
+								Key:  app.Identity.Key,
+							},
+							Available: false,
+						}
+
+						select {
+						case <-ctx.Done():
+						case responses <- res:
+						}
+
+						// Then wait for the application-specific context to be
+						// done, either because it's canceled properly, or
+						// because the test times out.
+						<-ctx.Done()
+
+						// Then we cancel the test's context. If everything is
+						// behaving correctly this should happen BEFORE the test
+						// times out, so we see a context.Canceled error and not
+						// DeadlineExceeded.
+						cancel()
+
+						return ctx.Err()
+					}
+
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(context.Canceled))
+				})
+
+				It("cancels the observer context when the server ends the stream", func() {
+					obs.ApplicationDiscoveredFunc = func(
+						ctx context.Context,
+						app Application,
+					) error {
+						// Close the "responses" channel which causes the server
+						// to return from the WatchApplications() method.
+						close(responses)
+
+						// Then wait for the application-specific context to be
+						// done, either because it's canceled properly, or
+						// because the test times out.
+						<-ctx.Done()
+
+						// Then we cancel the test's context. If everything is
+						// behaving correctly this should happen BEFORE the test
+						// times out, so we see a context.Canceled error and not
+						// DeadlineExceeded.
+						cancel()
+
+						return ctx.Err()
+					}
+
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(context.Canceled))
+				})
+
+				It("does not invoke the observer if the server sends a duplicate response", func() {
+					var count uint32
+
+					obs.ApplicationDiscoveredFunc = func(
+						_ context.Context,
+						app Application,
+					) error {
+						// Send the duplicate response the first time
+						// ApplicationDiscovered() is called.
+						if atomic.AddUint32(&count, 1) == 1 {
+							res := &discoverspec.WatchApplicationsResponse{
+								Identity: &discoverspec.Identity{
+									Name: "<app-name>",
+									Key:  "<app-key>",
+								},
+								Available: true,
+							}
+
+							select {
+							case <-ctx.Done():
+								return ctx.Err()
+							case responses <- res:
+								return nil
+							}
+						}
+
+						// If we've already been called return an error.
+						return errors.New("unexpected call")
+					}
+
+					// There's not much we can "expect" here other than that the
+					// test times out, since we're testing that something
+					// DOESN'T happen in its own goroutine.
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(context.DeadlineExceeded))
+				})
+			})
+
+			When("the server sends an invalid identity", func() {
+				BeforeEach(func() {
+					go func() {
+						res := &discoverspec.WatchApplicationsResponse{
+							Identity:  &discoverspec.Identity{}, // note: empty identity is invalid
+							Available: true,
+						}
+
+						select {
+						case <-ctx.Done():
+						case responses <- res:
+						}
+					}()
+				})
+
+				It("does not invoke the observer", func() {
+					obs.ApplicationDiscoveredFunc = func(
+						context.Context,
+						Application,
+					) error {
+						return errors.New("unexpected call")
+					}
+
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(context.DeadlineExceeded))
+				})
+
+				It("logs the error", func() {
+					discoverer.LogError = func(
+						c Connection,
+						err error,
+					) {
+						defer GinkgoRecover()
+						defer cancel()
+
+						Expect(c).To(Equal(conn))
+						Expect(err).To(MatchError(`invalid application identity: invalid name "", names must be non-empty, printable UTF-8 strings with no whitespace`))
+					}
+
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(context.Canceled))
+				})
+			})
+
+			When("the server produces an unexpected error", func() {
+				BeforeEach(func() {
+					server.WatchApplicationsFunc = func(
+						_ *discoverspec.WatchApplicationsRequest,
+						stream discoverspec.DiscoverAPI_WatchApplicationsServer,
+					) error {
+						return errors.New("<error>")
+					}
+				})
+
+				It("logs the error", func() {
+					discoverer.LogError = func(
+						c Connection,
+						err error,
+					) {
+						defer GinkgoRecover()
+						defer cancel()
+
+						Expect(c).To(Equal(conn))
+						Expect(err).To(MatchError(`unable to read from stream: rpc error: code = Unknown desc = <error>`))
+					}
+
+					err := discoverer.TargetConnected(ctx, conn)
+					Expect(err).To(Equal(context.Canceled))
+				})
+			})
+		})
+
+		When("the server does not implement the discovery API", func() {
+			BeforeEach(func() {
+				go gserver.Serve(listener)
+			})
+
+			It("returns nil immediately", func() {
+				err := discoverer.TargetConnected(ctx, conn)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+})
+
+// applicationObserverStub is a test implementation of the ApplicationObserver
+// interface.
+type applicationObserverStub struct {
+	ApplicationDiscoveredFunc func(context.Context, Application) error
+}
+
+// ApplicationDiscovered calls o.ApplicationDiscoveredFunc(ctx, a) if it is non-nil.
+func (o *applicationObserverStub) ApplicationDiscovered(ctx context.Context, a Application) error {
+	if o.ApplicationDiscoveredFunc != nil {
+		return o.ApplicationDiscoveredFunc(ctx, a)
+	}
+
+	return nil
+}
+
+type serverStub struct {
+	WatchApplicationsFunc func(*discoverspec.WatchApplicationsRequest, discoverspec.DiscoverAPI_WatchApplicationsServer) error
+}
+
+func (s *serverStub) WatchApplications(
+	req *discoverspec.WatchApplicationsRequest,
+	stream discoverspec.DiscoverAPI_WatchApplicationsServer,
+) error {
+	if s.WatchApplicationsFunc != nil {
+		return s.WatchApplicationsFunc(req, stream)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR introduces the `ApplicationDiscoverer` struct and associated types that use the DiscoverAPI to watch a gRPC target for announcements about application availability.

#### Why make this change?

This is the last part of the puzzle for discovering Dogma applications running on remote gRPC targets.

#### Is there anything you are unsure about?

There was this existing open issue https://github.com/dogmatiq/discoverkit/issues/4, but this new implementation has not retained any such `IsFatal()` methods. I'll learn if this is problematic when I switch Verity from the deprecated `configkit/api/discovery` package over to `discoverkit`.

#### What issues does this relate to?

None