### PR TITLE
Add `KubernetesEnvironmentTargetDiscoverer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
 <!-- references -->
-[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
-[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/
+[semantic versioning]: https://semver.org/spec/v2.0.0.html
+
+## Unreleased
+
+### Added
+
+- Add `KubernetesEnvironmentTargetDiscoverer`, which discoveres Kubernetes
+  services in the same namespace as the application
 
 ## [0.1.1] - 2021-01-20
 
@@ -24,7 +32,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Initial release
 
 <!-- references -->
-[Unreleased]: https://github.com/dogmatiq/discoverkit
+
+[unreleased]: https://github.com/dogmatiq/discoverkit
 [0.1.0]: https://github.com/dogmatiq/discoverkit/releases/tag/v0.1.0
 [0.1.1]: https://github.com/dogmatiq/discoverkit/releases/tag/v0.1.1
 

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -1,0 +1,90 @@
+package discoverkit
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc"
+)
+
+// DefaultKubernetesPortName is the default port name used to discover
+// Kubernetes services that are valid gRPC targets.
+const DefaultKubernetesPortName = "dogma"
+
+// KubernetesEnvironmentTargetDiscoverer discovers gRPC targets by inspecting
+// the environment for Kubernetes-style environment variables.
+type KubernetesEnvironmentTargetDiscoverer struct {
+	// PortName is the name (not the number) of the port used to identify a
+	// Dogma target.
+	//
+	// If it is empty, DefaultKubernetesPortName is used.
+	PortName string
+
+	// DialOptions returns the dial options used to dial the given address.
+	DialOptions func(addr string) []grpc.DialOption
+}
+
+// DiscoverTargets invokes an observer for each gRPC target that is discovered.
+//
+// It runs until ctx is canceled or an error occurs.
+//
+// The context passed to the observer is canceled when the target becomes
+// unavailable or the discover is stopped.
+//
+// The discoverer MAY block on calls to the observer. It is the observer's
+// responsibility to start new goroutines to handle background tasks, as
+// appropriate.
+func (d *KubernetesEnvironmentTargetDiscoverer) DiscoverTargets(
+	ctx context.Context,
+	obs TargetObserver,
+) error {
+	portName := d.PortName
+	if portName == "" {
+		portName = DefaultKubernetesPortName
+	}
+
+	separator := "_SERVICE_PORT_" +
+		kubernetesNameToEnv(portName) +
+		"="
+
+	for _, line := range os.Environ() {
+		i := strings.Index(line, separator)
+		if i < 0 {
+			continue
+		}
+
+		port := line[i+len(separator):]
+		if port == "" {
+			continue
+		}
+
+		host := os.Getenv(line[:i] + "_SERVICE_HOST")
+		if host == "" {
+			continue
+		}
+
+		t := Target{
+			Name: net.JoinHostPort(host, port),
+		}
+
+		if d.DialOptions != nil {
+			t.DialOptions = d.DialOptions(t.Name)
+		}
+
+		obs(ctx, t)
+	}
+
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
+// kubernetesNameToEnv converts a kubernetes resource name to an environment
+// variable name, as per Kubernetes own behavior.
+func kubernetesNameToEnv(s string) string {
+	return strings.ToUpper(
+		strings.ReplaceAll(s, "-", "_"),
+	)
+}

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1,0 +1,112 @@
+package discoverkit_test
+
+import (
+	"context"
+	"os"
+	"time"
+
+	. "github.com/dogmatiq/discoverkit"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type KubernetesEnvironmentTargetDiscoverer", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		disc   *KubernetesEnvironmentTargetDiscoverer
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+
+		disc = &KubernetesEnvironmentTargetDiscoverer{}
+
+		environment := map[string]string{
+			"DISCOVERKIT1_SERVICE_HOST":        "app1.example.org",
+			"DISCOVERKIT1_SERVICE_PORT_CUSTOM": "12345",
+			"DISCOVERKIT1_SERVICE_PORT_DOGMA":  "50555",
+
+			"DISCOVERKIT2_SERVICE_HOST":       "app2.example.org",
+			"DISCOVERKIT2_SERVICE_PORT_DOGMA": "80888",
+
+			"DISCOVERKIT3_SERVICE_PORT_DOGMA": "", // empty ports should be ignored
+
+			"DISCOVERKIT4_SERVICE_HOST":       "", // empty hosts should be ignored
+			"DISCOVERKIT4_SERVICE_PORT_DOGMA": "50555",
+		}
+
+		for k, v := range environment {
+			os.Setenv(k, v)
+		}
+
+		DeferCleanup(func() {
+			for k := range environment {
+				os.Unsetenv(k)
+			}
+		})
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func DiscoverTargets()", func() {
+		It("invokes the observer for each service with the named port", func() {
+			var (
+				actual []Target
+				expect = []Target{
+					{Name: "app1.example.org:50555"},
+					{Name: "app2.example.org:80888"},
+				}
+			)
+
+			err := disc.DiscoverTargets(
+				ctx,
+				func(
+					c context.Context,
+					t Target,
+				) {
+					Expect(c).To(BeIdenticalTo(ctx))
+					actual = append(actual, t)
+
+					if len(actual) == len(expect) {
+						cancel()
+					}
+				},
+			)
+
+			Expect(err).To(Equal(context.Canceled))
+			Expect(actual).To(ConsistOf(expect))
+		})
+
+		It("allows use of a custom port name", func() {
+			disc.PortName = "custom"
+
+			var (
+				actual []Target
+				expect = []Target{
+					{Name: "app1.example.org:12345"},
+				}
+			)
+
+			err := disc.DiscoverTargets(
+				ctx,
+				func(
+					c context.Context,
+					t Target,
+				) {
+					Expect(c).To(BeIdenticalTo(ctx))
+					actual = append(actual, t)
+
+					if len(actual) == len(expect) {
+						cancel()
+					}
+				},
+			)
+
+			Expect(err).To(Equal(context.Canceled))
+			Expect(actual).To(ConsistOf(expect))
+		})
+	})
+})


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `KubernetesEnvironmentTargetDiscoverer` target discoverer.

#### Why make this change?

To allow easy discovery of Kubernetes services that host a Dogma application without requiring a Kubernetes service account.

#### Is there anything you are unsure about?

The pod will need to be restarted if the services it needs have not been created in kubernetes before it starts. This does _not_ require that those services be _running_, but we may want to implement a more advanced discoverer in the future that watches an event stream of kubernetes updates so it can respond in real-time.

#### What issues does this relate to?

-
